### PR TITLE
ERC721.cairo test suite - incomplete

### DIFF
--- a/contracts/tokens/ERC721/ERC721.cairo
+++ b/contracts/tokens/ERC721/ERC721.cairo
@@ -144,10 +144,10 @@ func transfer{
     assert_not_zero(recipient)
 
     let (owner_balance) = _balances.read(sender)
-    let (new_owner_balance: Uint256) = uint256_sub(owner_balance, Uint256(0,1))
+    let (new_owner_balance: Uint256) = uint256_sub(owner_balance, Uint256(1,0))
 
     let (recipient_balance) = _balances.read(recipient)
-    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, Uint256(0,1))
+    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, Uint256(1,0))
 
     _balances.write(sender, new_owner_balance)
     _balances.write(recipient, new_recipient_balance)
@@ -197,10 +197,10 @@ func transfer_from{
     assert can_transfer = 1
 
     let (owner_balance) = _balances.read(sender)
-    let (new_owner_balance: Uint256) = uint256_sub(owner_balance, Uint256(0,1))
+    let (new_owner_balance: Uint256) = uint256_sub(owner_balance, Uint256(1,0))
 
     let (recipient_balance) = _balances.read(recipient)
-    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, Uint256(0,1))
+    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, Uint256(1,0))
 
     _balances.write(sender, new_owner_balance)
     _balances.write(recipient, new_recipient_balance)
@@ -229,11 +229,11 @@ func _mint{
     assert token_owner = 0 #already minted
 
     let (current_balance) = _balances.read(owner=recipient)
-    let (new_balance, _: Uint256) = uint256_add(current_balance, Uint256(0,1))
+    let (new_balance, _: Uint256) = uint256_add(current_balance, Uint256(1,0))
     _balances.write(recipient, new_balance)
 
     let (current_supply) = _total_supply.read()
-    let (new_supply, _: Uint256) = uint256_add(current_supply, Uint256(0,1))
+    let (new_supply, _: Uint256) = uint256_add(current_supply, Uint256(1,0))
     _total_supply.write(new_supply)
 
     _owners.write(token_id, recipient)
@@ -252,11 +252,11 @@ func _burn{
     assert_not_zero(owner) #not minted
 
     let (current_balance) = _balances.read(owner)
-    let (new_balance: Uint256) = uint256_sub(current_balance, Uint256(0,1))
+    let (new_balance: Uint256) = uint256_sub(current_balance, Uint256(1,0))
     _balances.write(owner, new_balance)
 
     let (current_supply) = _total_supply.read()
-    let (new_supply: Uint256) = uint256_sub(current_supply, Uint256(0,1))
+    let (new_supply: Uint256) = uint256_sub(current_supply, Uint256(1,0))
     _total_supply.write(new_supply)
 
     _owners.write(token_id, 0)

--- a/tests/mocks/MockERC721.cairo
+++ b/tests/mocks/MockERC721.cairo
@@ -212,6 +212,33 @@ func transfer_from{
     return ()
 end
 
+@external
+func mint{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    bitwise_ptr : BitwiseBuiltin*,
+    range_check_ptr
+}(
+    recipient: felt,
+    token_id: Uint256
+):
+    _mint(recipient, token_id)
+    return ()
+end
+
+@external
+func burn{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    bitwise_ptr : BitwiseBuiltin*,
+    range_check_ptr
+}(
+    token_id: Uint256
+):
+    _burn(token_id)
+    return ()
+end
+
 #############################################
 ##             INTERNAL LOGIC              ##
 #############################################

--- a/tests/mocks/MockERC721.cairo
+++ b/tests/mocks/MockERC721.cairo
@@ -144,10 +144,10 @@ func transfer{
     assert_not_zero(recipient)
 
     let (owner_balance) = _balances.read(sender)
-    let (new_owner_balance: Uint256) = uint256_sub(owner_balance, Uint256(0,1))
+    let (new_owner_balance: Uint256) = uint256_sub(owner_balance, Uint256(1,0))
 
     let (recipient_balance) = _balances.read(recipient)
-    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, Uint256(0,1))
+    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, Uint256(1,0))
 
     _balances.write(sender, new_owner_balance)
     _balances.write(recipient, new_recipient_balance)
@@ -197,10 +197,10 @@ func transfer_from{
     assert can_transfer = 1
 
     let (owner_balance) = _balances.read(sender)
-    let (new_owner_balance: Uint256) = uint256_sub(owner_balance, Uint256(0,1))
+    let (new_owner_balance: Uint256) = uint256_sub(owner_balance, Uint256(1,0))
 
     let (recipient_balance) = _balances.read(recipient)
-    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, Uint256(0,1))
+    let (new_recipient_balance, _: Uint256) = uint256_add(recipient_balance, Uint256(1,0))
 
     _balances.write(sender, new_owner_balance)
     _balances.write(recipient, new_recipient_balance)
@@ -238,7 +238,6 @@ func burn{
     _burn(token_id)
     return ()
 end
-
 #############################################
 ##             INTERNAL LOGIC              ##
 #############################################
@@ -256,11 +255,11 @@ func _mint{
     assert token_owner = 0 #already minted
 
     let (current_balance) = _balances.read(owner=recipient)
-    let (new_balance, _: Uint256) = uint256_add(current_balance, Uint256(0,1))
+    let (new_balance, _: Uint256) = uint256_add(current_balance, Uint256(1,0))
     _balances.write(recipient, new_balance)
 
     let (current_supply) = _total_supply.read()
-    let (new_supply, _: Uint256) = uint256_add(current_supply, Uint256(0,1))
+    let (new_supply, _: Uint256) = uint256_add(current_supply, Uint256(1,0))
     _total_supply.write(new_supply)
 
     _owners.write(token_id, recipient)
@@ -279,11 +278,11 @@ func _burn{
     assert_not_zero(owner) #not minted
 
     let (current_balance) = _balances.read(owner)
-    let (new_balance: Uint256) = uint256_sub(current_balance, Uint256(0,1))
+    let (new_balance: Uint256) = uint256_sub(current_balance, Uint256(1,0))
     _balances.write(owner, new_balance)
 
     let (current_supply) = _total_supply.read()
-    let (new_supply: Uint256) = uint256_sub(current_supply, Uint256(0,1))
+    let (new_supply: Uint256) = uint256_sub(current_supply, Uint256(1,0))
     _total_supply.write(new_supply)
 
     _owners.write(token_id, 0)

--- a/tests/test_ERC721.py
+++ b/tests/test_ERC721.py
@@ -2,6 +2,7 @@ import pytest
 import asyncio
 from starkware.starknet.testing.starknet import Starknet
 from utils import Signer, uint, str_to_felt
+from random import randint
 
 owner_signer = Signer(123456789987654321)
 friend_signer = Signer(69420)
@@ -46,7 +47,7 @@ async def test_constructor():
 @pytest.mark.asyncio
 async def test_mint():
     _, erc721, owner, _ = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     expected_owner = await erc721.owner_of(token).call()
     assert expected_owner.result.owner == owner.contract_address
@@ -57,7 +58,7 @@ async def test_mint():
 @pytest.mark.asyncio
 async def test_burn():
     _, erc721, owner, _ = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     await owner_signer.send_transaction(owner, erc721.contract_address, 'burn', [*token])
     expected_owner = await erc721.owner_of(token).call()
@@ -68,7 +69,7 @@ async def test_burn():
 @pytest.mark.asyncio
 async def test_approve():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     await owner_signer.send_transaction(owner, erc721.contract_address, 'approve', [friend.contract_address, *token])
     expected_spender = await erc721.get_approved(token).call()
@@ -77,7 +78,7 @@ async def test_approve():
 @pytest.mark.asyncio
 async def test_approve_burn():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     await owner_signer.send_transaction(owner, erc721.contract_address, 'approve', [friend.contract_address, *token])
     await owner_signer.send_transaction(owner, erc721.contract_address, 'burn', [*token])
@@ -94,7 +95,7 @@ async def test_approve_all():
 @pytest.mark.asyncio
 async def test_transfer_from():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     await owner_signer.send_transaction(owner, erc721.contract_address, 'approve', [friend.contract_address, *token])
     await friend_signer.send_transaction(friend, erc721.contract_address, 'transfer_from', [owner.contract_address, 666, *token])
@@ -111,7 +112,7 @@ async def test_transfer_from():
 @pytest.mark.asyncio
 async def test_transfer_from_self():
     _, erc721, owner, _ = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     await owner_signer.send_transaction(owner, erc721.contract_address, 'transfer_from', [owner.contract_address, 666, *token])
 
@@ -127,7 +128,7 @@ async def test_transfer_from_self():
 @pytest.mark.asyncio
 async def test_transfer_from_approve_all():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     await owner_signer.send_transaction(owner, erc721.contract_address, 'set_approval_for_all', [friend.contract_address, 1])
     await friend_signer.send_transaction(friend, erc721.contract_address, 'transfer_from', [owner.contract_address, 666, *token])
@@ -144,14 +145,14 @@ async def test_transfer_from_approve_all():
 @pytest.mark.asyncio
 async def test_fail_mint_to_zero():
     _, erc721, owner, _ = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     with pytest.raises(Exception):
         await erc721.mint(0, token).invoke()
 
 @pytest.mark.asyncio
 async def test_fail_double_mint():
     _, erc721, owner, _ = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     with pytest.raises(Exception):
         await erc721.mint(owner.contract_address, token).invoke()
@@ -159,14 +160,14 @@ async def test_fail_double_mint():
 @pytest.mark.asyncio
 async def test_fail_burn_unminted():
     _, erc721, owner, _ = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     with pytest.raises(Exception):
         await owner_signer.send_transaction(owner, erc721.contract_address, 'burn', [*token])
 
 @pytest.mark.asyncio
 async def test_fail_double_burn():
     _, erc721, owner, _ = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     await owner_signer.send_transaction(owner, erc721.contract_address, 'burn', [*token])
     with pytest.raises(Exception):
@@ -175,14 +176,14 @@ async def test_fail_double_burn():
 @pytest.mark.asyncio
 async def test_fail_approve_unminted():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     with pytest.raises(Exception):
         await owner_signer.send_transaction(owner, erc721.contract_address, 'approve', [friend.contract_address, *token])
 
 @pytest.mark.asyncio
 async def test_fail_approve_unauthorized():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     with pytest.raises(Exception):
         await friend_signer.send_transaction(friend, erc721.contract_address, 'approve', [666, *token])
@@ -190,14 +191,14 @@ async def test_fail_approve_unauthorized():
 @pytest.mark.asyncio
 async def test_fail_transfer_from_unowned():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     with pytest.raises(Exception):
         await owner_signer.send_transaction(owner, erc721.contract_address, 'transfer_from', [69, 420, *token])
 
 @pytest.mark.asyncio
 async def test_fail_transfer_from_wrong_from():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     with pytest.raises(Exception):
         await friend_signer.send_transaction(friend, erc721.contract_address, 'transfer_from', [69, 420, *token])
@@ -205,7 +206,7 @@ async def test_fail_transfer_from_wrong_from():
 @pytest.mark.asyncio
 async def test_fail_transfer_from_to_zero():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     with pytest.raises(Exception):
         await owner_signer.send_transaction(owner, erc721.contract_address, 'transfer_from', [owner.contract_address, 0, *token])
@@ -213,7 +214,7 @@ async def test_fail_transfer_from_to_zero():
 @pytest.mark.asyncio
 async def test_fail_transfer_from_not_owner():
     _, erc721, owner, friend = await ownable_factory()
-    token = uint(0)
+    token = uint(randint(0, 2**64))
     await erc721.mint(owner.contract_address, token).invoke()
     with pytest.raises(Exception):
         await friend_signer.send_transaction(friend, erc721.contract_address, 'transfer_from', [owner.contract_address, 666, *token])

--- a/tests/test_ERC721.py
+++ b/tests/test_ERC721.py
@@ -51,6 +51,7 @@ async def test_mint():
     expected_owner = await erc721.owner_of(token).call()
     assert expected_owner.result.owner == owner.contract_address
     expected_balance = await erc721.balance_of(owner.contract_address).call()
+    print (expected_balance.result.balance)
     assert expected_balance.result.balance == uint(1)
 
 @pytest.mark.asyncio

--- a/tests/test_ERC721.py
+++ b/tests/test_ERC721.py
@@ -1,0 +1,218 @@
+import pytest
+import asyncio
+from starkware.starknet.testing.starknet import Starknet
+from utils import Signer, uint, str_to_felt
+
+owner_signer = Signer(123456789987654321)
+friend_signer = Signer(69420)
+
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()
+
+
+async def ownable_factory():
+    starknet = await Starknet.empty()
+    owner = await starknet.deploy(
+        "contracts/utils/Account.cairo",
+        constructor_calldata=[owner_signer.public_key]
+    )
+
+    friend = await starknet.deploy(
+        "contracts/utils/Account.cairo",
+        constructor_calldata=[friend_signer.public_key]
+    )
+
+    erc721 = await starknet.deploy(
+        "tests/mocks/MockERC721.cairo",
+        constructor_calldata=[
+            str_to_felt("Test Contract"),
+            str_to_felt("TEST")
+        ]
+    )
+    return starknet, erc721, owner, friend
+
+
+@pytest.mark.asyncio
+async def test_constructor():
+    _, erc721, _, _ = await ownable_factory()
+    expected_name = await erc721.name().call()
+    assert expected_name.result.name == str_to_felt("Test Contract")
+    expected_symbol = await erc721.symbol().call()
+    assert expected_symbol.result.symbol == str_to_felt("TEST")
+
+
+@pytest.mark.asyncio
+async def test_mint():
+    _, erc721, owner, _ = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    expected_owner = await erc721.owner_of(token).call()
+    assert expected_owner.result.owner == owner.contract_address
+    expected_balance = await erc721.balance_of(owner.contract_address).call()
+    assert expected_balance.result.balance == uint(1)
+
+@pytest.mark.asyncio
+async def test_burn():
+    _, erc721, owner, _ = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    await owner_signer.send_transaction(owner, erc721.contract_address, 'burn', [*token])
+    expected_owner = await erc721.owner_of(token).call()
+    assert expected_owner.result.owner == 0
+    expected_balance = await erc721.balance_of(owner.contract_address).call()
+    assert expected_balance.result.balance == uint(0)
+
+@pytest.mark.asyncio
+async def test_approve():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    await owner_signer.send_transaction(owner, erc721.contract_address, 'approve', [friend.contract_address, *token])
+    expected_spender = await erc721.get_approved(token).call()
+    assert expected_spender.result.spender == friend.contract_address
+
+@pytest.mark.asyncio
+async def test_approve_burn():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    await owner_signer.send_transaction(owner, erc721.contract_address, 'approve', [friend.contract_address, *token])
+    await owner_signer.send_transaction(owner, erc721.contract_address, 'burn', [*token])
+    expected_spender = await erc721.get_approved(token).call()
+    assert expected_spender.result.spender == 0
+
+@pytest.mark.asyncio
+async def test_approve_all():
+    _, erc721, owner, friend = await ownable_factory()
+    await owner_signer.send_transaction(owner, erc721.contract_address, 'set_approval_for_all', [friend.contract_address, 1])
+    expected_approval = await erc721.is_approved_for_all(owner.contract_address, friend.contract_address,).call()
+    assert expected_approval.result.approved == 1
+
+@pytest.mark.asyncio
+async def test_transfer_from():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    await owner_signer.send_transaction(owner, erc721.contract_address, 'approve', [friend.contract_address, *token])
+    await friend_signer.send_transaction(friend, erc721.contract_address, 'transfer_from', [owner.contract_address, 666, *token])
+
+    expected_approval = await erc721.get_approved(token).call()
+    assert expected_approval.result.spender == 0
+    expected_owner = await erc721.owner_of(token).call()
+    assert expected_owner.result.owner == 666
+    expected_balance_from = await erc721.balance_of(owner.contract_address).call()
+    assert expected_balance_from.result.balance == uint(0)
+    expected_balance_to = await erc721.balance_of(666).call()
+    assert expected_balance_to.result.balance == uint(1)
+
+@pytest.mark.asyncio
+async def test_transfer_from_self():
+    _, erc721, owner, _ = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    await owner_signer.send_transaction(owner, erc721.contract_address, 'transfer_from', [owner.contract_address, 666, *token])
+
+    expected_approval = await erc721.get_approved(token).call()
+    assert expected_approval.result.spender == 0
+    expected_owner = await erc721.owner_of(token).call()
+    assert expected_owner.result.owner == 666
+    expected_balance_from = await erc721.balance_of(owner.contract_address).call()
+    assert expected_balance_from.result.balance == uint(0)
+    expected_balance_to = await erc721.balance_of(666).call()
+    assert expected_balance_to.result.balance == uint(1)
+
+@pytest.mark.asyncio
+async def test_transfer_from_approve_all():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    await owner_signer.send_transaction(owner, erc721.contract_address, 'set_approval_for_all', [friend.contract_address, 1])
+    await friend_signer.send_transaction(friend, erc721.contract_address, 'transfer_from', [owner.contract_address, 666, *token])
+
+    expected_approval = await erc721.get_approved(token).call()
+    assert expected_approval.result.spender == 0
+    expected_owner = await erc721.owner_of(token).call()
+    assert expected_owner.result.owner == 666
+    expected_balance_from = await erc721.balance_of(owner.contract_address).call()
+    assert expected_balance_from.result.balance == uint(0)
+    expected_balance_to = await erc721.balance_of(666).call()
+    assert expected_balance_to.result.balance == uint(1)
+
+@pytest.mark.asyncio
+async def test_fail_mint_to_zero():
+    _, erc721, owner, _ = await ownable_factory()
+    token = uint(0)
+    with pytest.raises(Exception):
+        await erc721.mint(0, token).invoke()
+
+@pytest.mark.asyncio
+async def test_fail_double_mint():
+    _, erc721, owner, _ = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    with pytest.raises(Exception):
+        await erc721.mint(owner.contract_address, token).invoke()
+
+@pytest.mark.asyncio
+async def test_fail_burn_unminted():
+    _, erc721, owner, _ = await ownable_factory()
+    token = uint(0)
+    with pytest.raises(Exception):
+        await owner_signer.send_transaction(owner, erc721.contract_address, 'burn', [*token])
+
+@pytest.mark.asyncio
+async def test_fail_double_burn():
+    _, erc721, owner, _ = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    await owner_signer.send_transaction(owner, erc721.contract_address, 'burn', [*token])
+    with pytest.raises(Exception):
+        await owner_signer.send_transaction(owner, erc721.contract_address, 'burn', [*token])
+
+@pytest.mark.asyncio
+async def test_fail_approve_unminted():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    with pytest.raises(Exception):
+        await owner_signer.send_transaction(owner, erc721.contract_address, 'approve', [friend.contract_address, *token])
+
+@pytest.mark.asyncio
+async def test_fail_approve_unauthorized():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    with pytest.raises(Exception):
+        await friend_signer.send_transaction(friend, erc721.contract_address, 'approve', [666, *token])
+
+@pytest.mark.asyncio
+async def test_fail_transfer_from_unowned():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    with pytest.raises(Exception):
+        await owner_signer.send_transaction(owner, erc721.contract_address, 'transfer_from', [69, 420, *token])
+
+@pytest.mark.asyncio
+async def test_fail_transfer_from_wrong_from():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    with pytest.raises(Exception):
+        await friend_signer.send_transaction(friend, erc721.contract_address, 'transfer_from', [69, 420, *token])
+
+@pytest.mark.asyncio
+async def test_fail_transfer_from_to_zero():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    with pytest.raises(Exception):
+        await owner_signer.send_transaction(owner, erc721.contract_address, 'transfer_from', [owner.contract_address, 0, *token])
+    
+@pytest.mark.asyncio
+async def test_fail_transfer_from_not_owner():
+    _, erc721, owner, friend = await ownable_factory()
+    token = uint(0)
+    await erc721.mint(owner.contract_address, token).invoke()
+    with pytest.raises(Exception):
+        await friend_signer.send_transaction(friend, erc721.contract_address, 'transfer_from', [owner.contract_address, 666, *token])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,7 @@ def str_to_felt(text):
 
 
 def uint(a):
-    return(0, a)
+    return(a, 0)
 
 
 async def assert_revert(fun):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,7 @@ def str_to_felt(text):
 
 
 def uint(a):
-    return(a, 0)
+    return(0, a)
 
 
 async def assert_revert(fun):


### PR DESCRIPTION
An incomplete serie of tests for `ERC721.cairo`, because it misses `tokenURI` tests and all `safe` features.

Also small fix of `uint`, the upper bits were set while it should have been the lower bits.