### PR TITLE
token_uri feature added to ERC721

### DIFF
--- a/contracts/tokens/ERC721/N-ERC721.cairo
+++ b/contracts/tokens/ERC721/N-ERC721.cairo
@@ -44,15 +44,15 @@ end
 #############################################
 
 @event
-func transfer(sender: felt, recipient: felt, tokenId: felt):
+func Transfer(sender: felt, recipient: felt, token_id: felt):
 end
 
 @event
-func approval(owner: felt, approved: felt, tokenId: felt):
+func Approval(owner: felt, approved: felt, token_id: felt):
 end
 
 @event
-func approval_for_all(owner: felt, operator: felt, approved: felt):
+func Approval_For_All(owner: felt, operator: felt, approved: felt):
 end
 
 #############################################
@@ -132,8 +132,8 @@ func approve{
 
     _token_approvals.write(token_id, spender)
 
-    ## Emit the approval event ##
-    approval.emit(owner=caller, approved=spender, tokenId=token_id)
+    ## Emit the Approval event ##
+    Approval.emit(caller, spender, token_id)
 
     return ()
 end
@@ -150,8 +150,8 @@ func set_approval_for_all{
     let (caller) = get_caller_address()
     _is_approved_for_all.write(caller, operator, approved)
 
-    ## Emit the approval event ##
-    approval_for_all.emit(owner=caller, operator=operator, approved=approved)
+    ## Emit the Approval event ##
+    Approval_For_All.emit(caller, operator, approved)
 
     return ()
 end
@@ -181,8 +181,8 @@ func transfer{
 
     _token_approvals.write(token_id, 0)
 
-    ## Emit the transfer event ##
-    transfer.emit(sender=caller, recipient=recipient, tokenId=token_id)
+    ## Emit the Transfer event ##
+    Transfer.emit(sender, recipient, token_id)
 
     return ()
 end
@@ -234,8 +234,8 @@ func transfer_from{
 
     _token_approvals.write(token_id, 0)
 
-    ## Emit the transfer event ##
-    transfer.emit(sender=sender, recipient=recipient, tokenId=token_id)
+    ## Emit the Transfer event ##
+    Transfer.emit(sender, recipient, token_id)
 
     return ()
 end

--- a/contracts/tokens/ERC721/N-ERC721.cairo
+++ b/contracts/tokens/ERC721/N-ERC721.cairo
@@ -11,6 +11,23 @@ from starkware.cairo.common.bitwise import bitwise_or
 ## @authors andreas <andreas@nascent.xyz> exp.table <github.com/exp-table>
 
 #############################################
+##                STRUCTS                  ##
+#############################################
+
+# in two parts because each felt can store a string of 31 bytes max
+# an IPFS hash is 46 bytes long
+struct baseURI:
+    member prefix : felt
+    member suffix : felt
+end
+
+struct tokenURI:
+    member prefix : felt
+    member suffix : felt
+    member token_id : felt
+end
+
+#############################################
 ##                METADATA                 ##
 #############################################
 
@@ -43,6 +60,10 @@ end
 #############################################
 
 @storage_var
+func _base_uri() -> (base_uri: baseURI):
+end
+
+@storage_var
 func _total_supply() -> (total_supply: felt):
 end
 
@@ -73,10 +94,12 @@ func constructor{
     range_check_ptr
 }(
     name: felt,
-    symbol: felt
+    symbol: felt,
+    base_uri: baseURI
 ):
     _name.write(name)
     _symbol.write(symbol)
+    _base_uri.write(base_uri)
 
     return()
 end
@@ -291,6 +314,17 @@ func symbol{
 end
 
 @view
+func token_uri{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}(token_id: felt) -> (token_uri: tokenURI):
+    let (base_uri : baseURI) = _base_uri.read()
+    let token_uri = tokenURI(base_uri.prefix, base_uri.suffix, token_id)
+    return (token_uri)
+end
+
+@view
 func total_supply{
     syscall_ptr: felt*,
     pedersen_ptr: HashBuiltin*,
@@ -339,3 +373,4 @@ func is_approved_for_all{
     let (approved) = _is_approved_for_all.read(owner, operator)
     return (approved)
 end
+

--- a/tests/test_ERC721.py
+++ b/tests/test_ERC721.py
@@ -29,7 +29,9 @@ async def ownable_factory():
         "tests/mocks/MockERC721.cairo",
         constructor_calldata=[
             str_to_felt("Test Contract"),
-            str_to_felt("TEST")
+            str_to_felt("TEST"),
+            str_to_felt("ipfs://"),
+            str_to_felt("hashkek")
         ]
     )
     return starknet, erc721, owner, friend
@@ -42,6 +44,10 @@ async def test_constructor():
     assert expected_name.result.name == str_to_felt("Test Contract")
     expected_symbol = await erc721.symbol().call()
     assert expected_symbol.result.symbol == str_to_felt("TEST")
+    expected_token_uri = await erc721.token_uri(uint(0)).call()
+    assert expected_token_uri.result.token_uri.prefix == str_to_felt("ipfs://")
+    assert expected_token_uri.result.token_uri.suffix == str_to_felt("hashkek")
+    assert expected_token_uri.result.token_uri.token_id == uint(0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_NERC721.py
+++ b/tests/test_NERC721.py
@@ -43,11 +43,10 @@ async def test_constructor():
     assert expected_name.result.name == str_to_felt("Test Contract")
     expected_symbol = await erc721.symbol().call()
     assert expected_symbol.result.symbol == str_to_felt("TEST")
-    expected_base_uri = await erc721.token_uri(0).call()
-    print (expected_base_uri.result.token_uri)
-    assert expected_base_uri.result.token_uriprefix == str_to_felt("ipfs://")
-    assert expected_base_uri.result.token_uri.suffix == str_to_felt("hashkek")
-    assert expected_base_uri.result.token_uri.token_id == 0
+    expected_token_uri = await erc721.token_uri(0).call()
+    assert expected_token_uri.result.token_uri.prefix == str_to_felt("ipfs://")
+    assert expected_token_uri.result.token_uri.suffix == str_to_felt("hashkek")
+    assert expected_token_uri.result.token_uri.token_id == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_NERC721.py
+++ b/tests/test_NERC721.py
@@ -28,7 +28,9 @@ async def ownable_factory():
         "tests/mocks/MockNERC721.cairo",
         constructor_calldata=[
             str_to_felt("Test Contract"),
-            str_to_felt("TEST")
+            str_to_felt("TEST"),
+            str_to_felt("ipfs://"),
+            str_to_felt("hashkek")
         ]
     )
     return starknet, erc721, owner, friend
@@ -41,6 +43,11 @@ async def test_constructor():
     assert expected_name.result.name == str_to_felt("Test Contract")
     expected_symbol = await erc721.symbol().call()
     assert expected_symbol.result.symbol == str_to_felt("TEST")
+    expected_base_uri = await erc721.token_uri(0).call()
+    print (expected_base_uri.result.token_uri)
+    assert expected_base_uri.result.token_uriprefix == str_to_felt("ipfs://")
+    assert expected_base_uri.result.token_uri.suffix == str_to_felt("hashkek")
+    assert expected_base_uri.result.token_uri.token_id == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR adds support for basic `token_uri` support and slight changes to events naming (first letter is upper case now) in order to follow as closely as possible the standard on Ethereum (bonus : `transfer` event was conflicting with the function).

Quick overview : 

- Two new structs 

```
struct baseURI:
    member prefix : felt
    member suffix : felt
end

struct tokenURI:
    member prefix : felt
    member suffix : felt
    member token_id : felt
end
```

`baseURI` has two fields, allowing a 62 bytes long string, to accomodate for IPFS (cid is 46 bytes long). It is set **once** in the constructor, possibility to change it later is left to the user.

`tokenURI` is only returned in the `token_uri-token_id)` function. Potential to eventually swap the `prefix` and `suffix` fields for a `baseURI` struct.

- New storage var

```
@storage_var
func _base_uri() -> (base_uri: baseURI):
end
```

- New view function

```
@view
func token_uri{
    syscall_ptr: felt*,
    pedersen_ptr: HashBuiltin*,
    range_check_ptr
}(token_id: felt) -> (token_uri: tokenURI):
    let (base_uri : baseURI) = _base_uri.read()
    let token_uri = tokenURI(base_uri.prefix, base_uri.suffix, token_id)
    return (token_uri)
end
```